### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Status
 
 |Build Status|\ |Coverage Status|
 
-.. _Read the Docs: http://vanillapy.readthedocs.org/
+.. _Read the Docs: https://vanillapy.readthedocs.io/
 .. |Vanilla| image:: https://raw.githubusercontent.com/cablehead/vanilla/master/docs/_static/logo2.png
 .. |Build Status| image:: https://img.shields.io/travis/cablehead/vanilla.svg?style=flat-square
    :target: https://travis-ci.org/cablehead/vanilla

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
 
 
 description = "Straightforward concurrency for Python " \
-    "http://vanillapy.readthedocs.org/"
+    "https://vanillapy.readthedocs.io/"
 
 
 class PyTest(TestCommand):


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
